### PR TITLE
Extend explanation of skipped status

### DIFF
--- a/docs/apache-airflow/core-concepts/tasks.rst
+++ b/docs/apache-airflow/core-concepts/tasks.rst
@@ -79,7 +79,7 @@ The possible states for a Task Instance are:
 * ``shutdown``: The task was externally requested to shut down when it was running
 * ``restarting``: The task was externally requested to restart when it was running
 * ``failed``: The task had an error during execution and failed to run
-* ``skipped``: The task was skipped due to branching, LatestOnly, or the DAG has timed out, and had no time left for this task.
+* ``skipped``: The task was skipped due to branching, LatestOnly, or the DAG run has timed out, and had no time left for this task.
 * ``upstream_failed``: An upstream task failed and the :ref:`Trigger Rule <concepts:trigger-rules>` says we needed it
 * ``up_for_retry``: The task failed, but has retry attempts left and will be rescheduled.
 * ``up_for_reschedule``: The task is a :doc:`Sensor <sensors>` that is in ``reschedule`` mode

--- a/docs/apache-airflow/core-concepts/tasks.rst
+++ b/docs/apache-airflow/core-concepts/tasks.rst
@@ -79,7 +79,7 @@ The possible states for a Task Instance are:
 * ``shutdown``: The task was externally requested to shut down when it was running
 * ``restarting``: The task was externally requested to restart when it was running
 * ``failed``: The task had an error during execution and failed to run
-* ``skipped``: The task was skipped due to branching, LatestOnly, or similar.
+* ``skipped``: The task was skipped due to branching, LatestOnly, or the DAG has timed out, and had no time left for this task.
 * ``upstream_failed``: An upstream task failed and the :ref:`Trigger Rule <concepts:trigger-rules>` says we needed it
 * ``up_for_retry``: The task failed, but has retry attempts left and will be rescheduled.
 * ``up_for_reschedule``: The task is a :doc:`Sensor <sensors>` that is in ``reschedule`` mode


### PR DESCRIPTION
Extend explanation of `skipped` status, that it is frequently caused by DAG timeout.
